### PR TITLE
Add basic color listing page

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
+import { ColorsPage } from "./components/colors-page";
 import { IDEPreview } from "./components/ide-preview";
+import { PageSwitcher } from "./components/page-switcher";
 import { PreviewSwitcher } from "./components/preview-switcher";
 import { TerminalPreview } from "./components/terminal-preview";
 import { ThemeSelector } from "./components/theme-selector";
@@ -11,6 +13,9 @@ export function App() {
 	const [selectedPreview, setSelectedPreview] = useState<"ide" | "terminal">(
 		"ide",
 	);
+	const [selectedPage, setSelectedPage] = useState<"preview" | "colors">(
+		"preview",
+	);
 	const theme = themes[selectedTheme];
 
 	return (
@@ -21,20 +26,30 @@ export function App() {
 						selectedTheme={selectedTheme}
 						onThemeChange={setSelectedTheme}
 					/>
-					<PreviewSwitcher
-						selectedPreview={selectedPreview}
-						onPreviewChange={setSelectedPreview}
+					<PageSwitcher
+						selectedPage={selectedPage}
+						onPageChange={setSelectedPage}
 					/>
+					{selectedPage === "preview" && (
+						<PreviewSwitcher
+							selectedPreview={selectedPreview}
+							onPreviewChange={setSelectedPreview}
+						/>
+					)}
 				</div>
 
 				<h1 className="py-2 font-bold">Tokyo Tools</h1>
 			</header>
 
 			<main className="flex justify-center">
-				{selectedPreview === "ide" ? (
-					<IDEPreview theme={theme} />
+				{selectedPage === "preview" ? (
+					selectedPreview === "ide" ? (
+						<IDEPreview theme={theme} />
+					) : (
+						<TerminalPreview theme={theme} />
+					)
 				) : (
-					<TerminalPreview theme={theme} />
+					<ColorsPage theme={theme} />
 				)}
 			</main>
 		</div>

--- a/src/components/colors-page.tsx
+++ b/src/components/colors-page.tsx
@@ -1,0 +1,30 @@
+import { getColorCategories } from "../themes/color-categories.ts";
+import type { GenericTheme } from "../themes/generic-theme.ts";
+
+interface ColorsPageProps {
+	theme: GenericTheme;
+}
+
+export function ColorsPage({ theme }: ColorsPageProps) {
+	const colors = getColorCategories(theme);
+
+	return (
+		<div className="flex flex-col gap-4">
+			<ColorItem label="Primary" color={colors.primary} />
+			<ColorItem label="Secondary" color={colors.secondary} />
+			<ColorItem label="Canvas Foreground" color={colors.canvas.foreground} />
+			<ColorItem label="Canvas Background" color={colors.canvas.background} />
+		</div>
+	);
+}
+
+function ColorItem({ label, color }: { label: string; color: string }) {
+	return (
+		<div className="flex items-center gap-4">
+			<div className="h-8 w-8 rounded" style={{ backgroundColor: color }} />
+			<span className="font-mono">
+				{label}: {color}
+			</span>
+		</div>
+	);
+}

--- a/src/components/page-switcher.tsx
+++ b/src/components/page-switcher.tsx
@@ -1,0 +1,27 @@
+import { Tab } from "./tab";
+import { Tabs } from "./tabs";
+
+interface PageSwitcherProps {
+	selectedPage: "preview" | "colors";
+	onPageChange: (page: "preview" | "colors") => void;
+}
+
+export function PageSwitcher({
+	selectedPage,
+	onPageChange,
+}: PageSwitcherProps) {
+	return (
+		<Tabs>
+			<Tab
+				label="Preview"
+				isSelected={selectedPage === "preview"}
+				onClick={() => onPageChange("preview")}
+			/>
+			<Tab
+				label="Colors"
+				isSelected={selectedPage === "colors"}
+				onClick={() => onPageChange("colors")}
+			/>
+		</Tabs>
+	);
+}

--- a/src/themes/color-categories.ts
+++ b/src/themes/color-categories.ts
@@ -1,0 +1,21 @@
+import type { GenericTheme } from "./generic-theme.ts";
+
+export interface ColorCategories {
+	primary: string;
+	secondary: string;
+	canvas: {
+		foreground: string;
+		background: string;
+	};
+}
+
+export function getColorCategories(theme: GenericTheme): ColorCategories {
+	return {
+		primary: theme.brand.primary,
+		secondary: theme.text.secondary,
+		canvas: {
+			foreground: theme.text.primary,
+			background: theme.surfaces.canvas,
+		},
+	};
+}


### PR DESCRIPTION
## Summary
- introduce ColorCategories interface for primary/secondary and canvas colors
- add color listing page and page switcher to view theme palette
- wire new page into app for quick theme color overview

## Testing
- `npm test` (fails: Missing script "test")
- `npx biome check .`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bf9982f908332b285d27a59048773